### PR TITLE
Add readme paths in kitspace.yaml

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -5,42 +5,50 @@ multi:
         site: https://www.envox.hr/eez/eez-bench-box-3/eez-dib-stm32f7-mcu-board.html
         gerbers: mcu/Gerber files
         bom: mcu/BOM/1-click-bom.csv
+        readme: mcu/README.md
     aux-ps:
         summary: BB3 AUX-PS board
         color: blue
         site: https://www.envox.hr/eez/eez-bench-box-3/eez-dib-aux-power-supply.html
         gerbers: aux-ps/Gerber files
         bom: aux-ps/BOM/1-click-bom.csv
+        readme: aux-ps/README.md
     bp3c:
         summary: BB3 backplane module
         color: green
         site: https://www.envox.hr/eez/eez-bench-box-3/eez-dib-bp3c-backplane.html
         gerbers: bp3c/Gerber files
         bom: bp3c/BOM/1-click-bom.csv
+        readme: bp3c/README.md
     dcm220:
         summary: BB3 DCM220 module
         color: green
         site: https://www.envox.hr/eez/eez-bench-box-3/eez-dib-dcm220-dual-power-module.html
         gerbers: dcm220/Gerber files
         bom: dcm220/BOM/1-click-bom.csv
+        readme: dcm220/README.md
     dcp405:
         summary: BB3 DCP405 module
         color: blue
         site: https://www.envox.hr/eez/eez-bench-box-3/eez-dib-dcp405-power-module.html
         gerbers: dcp405/Gerber files
         bom: dcp405/BOM/1-click-bom.csv
+        readme: dcp405/README.md
     aux-ps-cs:
         summary: BB3 AUX-PS board (Crowd Supply edition)
         color: green
         gerbers: previous designs/aux-ps r3B3 (Crowd Supply edition)/Gerber files
         bom: previous designs/aux-ps r3B3 (Crowd Supply edition)/BOM/1-click-bom.csv
+        readme: previous designs/aux-ps r3B3 (Crowd Supply edition)/README.md
     mcu-cs:
         summary: BB3 MCU board (Crowd Supply edition)
         color: green
         gerbers: previous designs/mcu r2B4 (Crowd Supply edition)/Gerber files
         bom: previous designs/mcu r2B4 (Crowd Supply edition)/BOM/1-click-bom.csv
+        readme: previous designs/mcu r2B4 (Crowd Supply edition)/README.md
     dcp405-cs:
         summary: BB3 DCP405 module (Crowd Supply edition)
         color: green
         gerbers: previous designs/dcp405 r2B11 (Crowd Supply edition)/Gerber files
         bom: previous designs/dcp405 r2B11 (Crowd Supply edition)/BOM/1-click-bom.csv
+        readme: previous designs/dcp405 r2B11 (Crowd Supply edition)/README.md


### PR DESCRIPTION
Hi, it's Abdulrahman from Kitspace.org :wave: 

We are very close to the alpha release of [kitspace-v2](https://github.com/kitspace/kitspace-v2).
While testing, we noticed that modular-psu projects, could have better READMEs just by adding the paths in `kitspace.yaml`.

Currently, all projects have the [repo README](https://github.com/eez-open/modular-psu/blob/master/README.md), instead of the project-specific README. This PR adds `readme` paths to all projects. Here is how the README would look on kitspace for the `mcu` project after merging,
|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/37152329/219300641-461fde2b-580a-4f19-96f8-8832562c1d4f.png)|![image](https://user-images.githubusercontent.com/37152329/219300694-29ba0693-59e0-4b07-afa8-e8843a2253dc.png)|

Could you please review these changes and accept them if they are convenient?
